### PR TITLE
Add new rules for different dashes

### DIFF
--- a/prepress.py
+++ b/prepress.py
@@ -183,12 +183,13 @@ def replace_dashes(article: Article) -> Article:
     text_tag: bs4.NavigableString
     for text_tag in article.content.find_all(text=True):
         new_tag = re.sub(r'(?<=\d) ?--? ?(?=\d)', '–', text_tag)
-                    .replace(' - ', ' — ')
-                    .replace(' --- ', ' — ')
-                    .replace('---', ' — ')
-                    .replace(' -- ', ' — ')
-                    .replace('--', ' — ')
+                    .replace(' - ', ' — ')
+                    .replace(' --- ', ' — ')
+                    .replace('---', ' — ')
+                    .replace(' -- ', ' — ')
+                    .replace('--', ' — ')
                     .replace(' — ', ' — ')
+                    .replace('—', ' — ')
         text_tag.replace_with(new_tag)
     return article
 

--- a/prepress.py
+++ b/prepress.py
@@ -177,10 +177,16 @@ def replace_ellipses(article: Article) -> Article:
 def replace_dashes(article: Article) -> Article:
     """Replaces hyphens used as spacing, that is, when they are surrounded with spaces,
     with em dashes.
+    Also replaces hyphens in numeric ranges with en dashes.
     """
     text_tag: bs4.NavigableString
     for text_tag in article.content.find_all(text=True):
         new_tag = text_tag.replace(' - ', ' — ')
+                          .replace(' --- ', ' — ')
+                          .replace('---', ' — ')
+                          .replace(' -- ', ' — ')
+                          .replace('--', ' — ')
+        new_tag = re.sub(r'(?<=\d) ?--? ?(?=\d)', '–', text_tag)
         text_tag.replace_with(new_tag)
     return article
 

--- a/prepress.py
+++ b/prepress.py
@@ -187,6 +187,7 @@ def replace_dashes(article: Article) -> Article:
                           .replace('---', ' — ')
                           .replace(' -- ', ' — ')
                           .replace('--', ' — ')
+                          .repalce(' — ', ' — ')
         new_tag = re.sub(r'(?<=\d) ?--? ?(?=\d)', '–', text_tag)
         text_tag.replace_with(new_tag)
     return article

--- a/prepress.py
+++ b/prepress.py
@@ -182,13 +182,13 @@ def replace_dashes(article: Article) -> Article:
     """
     text_tag: bs4.NavigableString
     for text_tag in article.content.find_all(text=True):
-        new_tag = text_tag.replace(' - ', ' — ')
-                          .replace(' --- ', ' — ')
-                          .replace('---', ' — ')
-                          .replace(' -- ', ' — ')
-                          .replace('--', ' — ')
-                          .repalce(' — ', ' — ')
         new_tag = re.sub(r'(?<=\d) ?--? ?(?=\d)', '–', text_tag)
+                    .replace(' - ', ' — ')
+                    .replace(' --- ', ' — ')
+                    .replace('---', ' — ')
+                    .replace(' -- ', ' — ')
+                    .replace('--', ' — ')
+                    .replace(' — ', ' — ')
         text_tag.replace_with(new_tag)
     return article
 

--- a/prepress.py
+++ b/prepress.py
@@ -143,7 +143,8 @@ def compile_latex(article: Article) -> Article:
                 continue
             #just use the hash of the latex for a unique filename, this should probably never collide
             filename = article.get_pdf_location(str(hash(latex)))
-            compile_latex_str(latex, filename)
+            if not os.path.isfile(filename):
+                compile_latex_str(latex, filename)
             #if we can't find the parent, assume it's just the document
             parent: Tag
             if text_tag.parent == None or text_tag.parent.name == '[document]':


### PR DESCRIPTION
This PR introduces rules for the following forms of dashes:

- ` --- ` turns into ` — `
- `---` turns into ` — `
- ` -- ` turns into ` — `
- `--` turns into ` — `
- ` — ` turns into ` — `
- `—` turns into ` — `

Note that em dashes are surrounded by a thin space, and not a regular space.

As well, it turns `-` or `--` used in numeric ranges into em dashes (`–`).