### PR TITLE
Improve the smart quotes algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ issue.xml
 
 #ignore wordpress dump
 wordpress_dump.xml
+
+# python bytecode, ugh
+*.pyc

--- a/prepress.py
+++ b/prepress.py
@@ -338,8 +338,14 @@ def add_smart_quotes(article: Article) -> Article:
             glued_tag = glued_tag + after_tag[0]
 
         replaced = replace_smart_quotes(glued_tag)
+
         # and remove the characters we glued on
-        tag.replace_with(replaced[1:-1])
+        if before_tag is not None:
+            replaced = replaced[1:]
+        if after_tag is not None:
+            replaced = replaced[:-1]
+            
+        tag.replace_with(replaced)
 
     return article
 

--- a/prepress.py
+++ b/prepress.py
@@ -286,15 +286,32 @@ def replace_double_quote(before: str, after: str):
 
     return STRAIGHT_DOUBLE_QUOTE
 
+LEFT_SINGLE_QUOTE = '‘'
+RIGHT_SINGLE_QUOTE = '’'
+STRAIGHT_SINGLE_QUOTE = '\''
+
+def replace_single_quote(before: str, after: str):
+    # the rules for single quotes are the same as double quotes
+    double_quote = replace_double_quote(before, after)
+    if double_quote == RIGHT_DOUBLE_QUOTE:
+        return RIGHT_SINGLE_QUOTE
+    elif double_quote == LEFT_DOUBLE_QUOTE:
+        return LEFT_SINGLE_QUOTE
+    elif double_quote == STRAIGHT_DOUBLE_QUOTE:
+        return STRAIGHT_SINGLE_QUOTE
+
+
 def replace_smart_quotes(s: str):
     # create an array so we can modify this string
     char_array = list(s)
     
     for idx, char in enumerate(char_array):
+        before = None if idx == 0 else char_array[idx - 1]
+        after = None if idx == len(char_array) - 1 else char_array[idx + 1]
         if char == '"':
-            before = None if idx == 0 else char_array[idx - 1]
-            after = None if idx == len(char_array) - 1 else char_array[idx + 1]
             char_array[idx] = replace_double_quote(before, after)
+        if char == '\'':
+            char_array[idx] = replace_single_quote(before, after)
 
     return ''.join(char_array)
     

--- a/prepress.py
+++ b/prepress.py
@@ -258,7 +258,7 @@ def replace_dashes(article: Article) -> Article:
 # Quotes only really start with varieties of left brackets
 LEFT_PUNCTUATION = { '(', '{', '<' }
 # But they can be ended with any of the standard sentence enders
-RIGHT_PUNCTUATION = { ')', '}', '>', '.', ',', '?' }
+RIGHT_PUNCTUATION = { ')', '}', '>', '.', ',', '?', '!' }
 LEFT_DOUBLE_QUOTE = '“'
 RIGHT_DOUBLE_QUOTE = '”'
 STRAIGHT_DOUBLE_QUOTE = '"'

--- a/prepress.py
+++ b/prepress.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import os.path
-from smart_quotes import get_double_quote, get_quote_direction, get_single_quote
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from typing import List, Callable, Union

--- a/smart_quotes.py
+++ b/smart_quotes.py
@@ -1,0 +1,52 @@
+import enum
+
+class QuoteDir(enum.Enum):
+    Left = 'left',
+    Right = 'right',
+    Straight = 'straight'
+
+# Quotes only really start with varieties of left brackets
+LEFT_PUNCTUATION = { '(', '{', '<' }
+# But they can be ended with any of the standard sentence enders
+RIGHT_PUNCTUATION = { ')', '}', '>', '.', ',', '?', '!' }
+
+DOUBLE_QUOTES = {
+    QuoteDir.Left: '“',
+    QuoteDir.Right: '”',
+    QuoteDir.Straight: '"'
+}
+
+SINGLE_QUOTES = {
+    QuoteDir.Left: '‘',
+    QuoteDir.Right: '’',
+    QuoteDir.Straight: '\''
+}
+
+def get_quote_direction(before: str, after: str):
+    # double quotes can occur at the beginning/end of strings
+    if before is None:
+        return QuoteDir.Left
+    if after is None:
+        return QuoteDir.Right
+
+    # double quotes can occur before/after spaces
+    if before.isspace():
+        return QuoteDir.Left
+    # ditto for the right
+    if after.isspace():
+        return QuoteDir.Right
+
+    # double quotes can occur before/after punctuation
+    if before in LEFT_PUNCTUATION:
+        return QuoteDir.Left
+    if after in RIGHT_PUNCTUATION:
+        return QuoteDir.Right
+
+
+    return QuoteDir.Straight
+
+def get_double_quote(dir: QuoteDir):
+    return DOUBLE_QUOTES[dir]
+
+def get_single_quote(dir: QuoteDir):
+    return SINGLE_QUOTES[dir]

--- a/tests/test_smart_quotes.py
+++ b/tests/test_smart_quotes.py
@@ -58,3 +58,19 @@ class TestSmartQuotes(unittest.TestCase):
             ),
             'He said, “why”!'
         )
+
+    def test_single_quotes(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'He said, "I didn\'t say \'that\'.".'
+            ),
+            'He said, “I didn\'t say ‘that’.”.'
+        )
+
+    def test_apostrophes(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'Whoms\'tve\'s.'
+            ),
+        'Whoms\'tve\'s.'
+        )

--- a/tests/test_smart_quotes.py
+++ b/tests/test_smart_quotes.py
@@ -74,3 +74,11 @@ class TestSmartQuotes(unittest.TestCase):
             ),
         'Whoms\'tve\'s.'
         )
+
+    def test_formatting(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'prefers "<em>great literature</em>."'
+            ),
+            'prefers “<em>great literature</em>.”'
+        )

--- a/tests/test_smart_quotes.py
+++ b/tests/test_smart_quotes.py
@@ -1,0 +1,44 @@
+import unittest
+from prepress import replace_smart_quotes
+
+class TestSmartQuotes(unittest.TestCase):
+
+    def test_basic(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'He said, "no".'
+            ),
+            'He said, “no”.'
+        )
+
+    def test_sentence_start(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                '"Weird, right?", he said.'
+            ),
+            '“Weird, right?”, he said.'
+        )
+
+    def test_sentence_end(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'Said he, "Weird, right?"'
+            ),
+            'Said he, “Weird, right?”'
+        )
+
+    def test_short_quote(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                '"a", "a", "a"'
+            ),
+        '“a”, “a”, “a”'
+        )
+
+    def test_nested_quotes(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                '"He said, "pog"?"'
+            ),
+            '“He said, “pog”?”'
+        )

--- a/tests/test_smart_quotes.py
+++ b/tests/test_smart_quotes.py
@@ -42,3 +42,19 @@ class TestSmartQuotes(unittest.TestCase):
             ),
             '“He said, “pog”?”'
         )
+
+    def test_question_mark(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'He said, "why"?'
+            ),
+            'He said, “why”?'
+        )
+
+    def test_exclamation_mark(self):
+        self.assertEqual(
+            replace_smart_quotes(
+                'He said, "why"!'
+            ),
+            'He said, “why”!'
+        )


### PR DESCRIPTION
This PR switches the smart quotes algorithm from matching pairs to using the character directly before/after the quote to determine which quote to use.

This should fix problems with quotes becoming inverted midway through articles.